### PR TITLE
Add pagination to the validators query

### DIFF
--- a/src/services/queries/uptime.ts
+++ b/src/services/queries/uptime.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { API_ENDPOINTS } from "@/constants/endpoints";
 
+const DEFAULT_LIMIT = 1000
+
 interface Validator {
   operatorAddress: string;
   moniker: string;
@@ -25,7 +27,7 @@ export const useValidatorsData = () => {
     queryKey: ["validators-data"],
     queryFn: async () => {
       const response = await fetch(
-        `${API_ENDPOINTS.LCD}/cosmos/staking/v1beta1/validators`
+        `${API_ENDPOINTS.LCD}/cosmos/staking/v1beta1/validators?pagination.limit=${DEFAULT_LIMIT}`
       );
       const data = await response.json();
       return data.validators;


### PR DESCRIPTION
# Description

Add the pagination parameter to the get validators query.
This is an issue reported by the marketing and Ops teams. They were not able to get validators because they were hidden by the pagination.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

Tested locally