### PR TITLE
Aded claim Reward on user profile

### DIFF
--- a/src/app/account/[address]/page.tsx
+++ b/src/app/account/[address]/page.tsx
@@ -363,7 +363,6 @@ export default function AddressPage() {
 
       const normalBalance = parseFloat(balance?.formatted || "0");
       const stakingBalance = parseFloat(formatAmount(totalStaking.toString()));
-      const totalBalance = normalBalance + stakingBalance;
 
       let totalWithdrawn = 0;
       if (withdrawHistoryData?.rewards) {
@@ -378,25 +377,21 @@ export default function AddressPage() {
       const withdrawBalance = parseFloat(
         formatAmount(totalWithdrawn.toString())
       );
-      const totalWithWithdraws = totalBalance + withdrawBalance;
+      const totalBalance =
+        normalBalance + withdrawBalance + totalRewards + totalStaking;
 
-      setPercentages({
-        balancePercentage: ((normalBalance / totalWithWithdraws) * 100).toFixed(
+      const percentages = {
+        balancePercentage: ((normalBalance / totalBalance) * 100).toFixed(2),
+        stakingPercentage: ((stakingBalance / totalBalance) * 100).toFixed(2),
+        rewardsPercentage: ((totalRewards / totalBalance) * 100).toFixed(2),
+        withdrawalsPercentage: ((withdrawBalance / totalBalance) * 100).toFixed(
           2
         ),
-        stakingPercentage: ((stakingBalance / totalWithdrawn) * 100).toFixed(2),
-        rewardsPercentage: (
-          (totalRewards / Math.pow(10, 18) / totalWithdrawn) *
-          100
-        ).toFixed(2),
-        withdrawalsPercentage: (
-          (withdrawBalance / totalWithdrawn) *
-          100
-        ).toFixed(2),
-      });
+      };
+      setPercentages(percentages);
 
       walletData.staking = `${formatAmount(totalStaking.toString())} KII`;
-      walletData.reward = `${formatUnits(totalRewards)} KII`;
+      walletData.reward = `${formatUnits(BigInt(totalRewards))} KII`;
       walletData.withdrawals = `${formatAmount(totalWithdrawn.toString())} KII`;
 
       if (delegationsData.delegation_responses) {

--- a/src/app/account/[address]/page.tsx
+++ b/src/app/account/[address]/page.tsx
@@ -26,6 +26,8 @@ import {
 } from "@/services/mutations/staking";
 import { useHexToBech } from "@/services/hooks/addressConvertion";
 import { KIICHAIN_BASE_DENOM } from "@kiichain/kiijs-evm";
+import { formatUnits } from "ethers";
+import { RewardsTable } from "@/components/Account/RewardsTable";
 
 interface Theme {
   bgColor: string;
@@ -394,7 +396,7 @@ export default function AddressPage() {
       });
 
       walletData.staking = `${formatAmount(totalStaking.toString())} KII`;
-      walletData.reward = `${formatAmount(totalRewards.toString())} KII`;
+      walletData.reward = `${formatUnits(totalRewards)} KII`;
       walletData.withdrawals = `${formatAmount(totalWithdrawn.toString())} KII`;
 
       if (delegationsData.delegation_responses) {
@@ -477,6 +479,13 @@ export default function AddressPage() {
         ]}
       />
       <WithdrawalsTable cosmosAddress={cosmosAddress!} />
+
+      <RewardsTable
+        rewardsData={rewardsData}
+        theme={theme}
+        validators={validatorMap}
+        isOwner={isOwner}
+      />
 
       <StakesTable
         delegations={delegations}

--- a/src/components/Account/BalanceAndAssets.tsx
+++ b/src/components/Account/BalanceAndAssets.tsx
@@ -26,7 +26,7 @@ export function BalanceAndAssets({ assets }: BalanceAndAssetsProps) {
     return {
       ...asset,
       amount: amount.toFixed(4) + " KII",
-      value: parseFloat(asset.value.replace("$", "")).toFixed(4),
+      value: parseFloat(asset.value.replace("$", "")).toFixed(6),
       percentage: `${isNaN(percentage) ? "0" : percentage.toFixed(2)}%`,
       numericPercentage: isNaN(percentage) ? 0 : Number(percentage.toFixed(2)),
     };

--- a/src/components/Account/RewardsTable.tsx
+++ b/src/components/Account/RewardsTable.tsx
@@ -1,0 +1,185 @@
+import { useAccount, useWalletClient } from "wagmi";
+import { toast } from "react-toastify";
+import { RewardsResponse } from "@/services/queries/rewards";
+import { formatUnits } from "ethers";
+import { Theme } from "./StakesTable";
+import {
+  useWithdrawAllRewardsMutation,
+  useWithdrawRewardsMutation,
+} from "@/services/mutations/distribution";
+import { WagmiConnectButton } from "../ui/WagmiConnectButton";
+import { FaSpinner } from "react-icons/fa";
+
+interface RewardsTableProps {
+  rewardsData: RewardsResponse | undefined;
+  theme: Theme;
+  validators: Record<string, string>;
+  isOwner: boolean;
+}
+
+export function RewardsTable({
+  rewardsData,
+  theme,
+  validators,
+  isOwner,
+}: RewardsTableProps) {
+  const { address, isConnected } = useAccount();
+  const { data: walletClient } = useWalletClient();
+  const withdrawRewardMutation = useWithdrawRewardsMutation();
+  const withdrawAllRewardMutation = useWithdrawAllRewardsMutation();
+
+  const handleClaim = (validatorAddress: string) => {
+    if (!isConnected || !address) {
+      toast.error("Connect your wallet to claim rewards");
+      return;
+    }
+
+    withdrawRewardMutation.mutate({
+      validatorAddr: validatorAddress,
+      walletClient: walletClient,
+    });
+  };
+
+  const handleAllClaim = () => {
+    if (!isConnected) {
+      toast.error("Connect your wallet to claim all rewards");
+      return;
+    }
+
+    withdrawAllRewardMutation.mutate({
+      walletClient: walletClient,
+    });
+  };
+
+  return (
+    <div
+      className="mt-8 p-6 rounded-lg relative"
+      style={{ backgroundColor: theme.boxColor }}
+    >
+      <div className="mb-6">
+        <div className="mb-4 text-xl" style={{ color: theme.primaryTextColor }}>
+          Rewards
+        </div>
+        <div className="w-full overflow-x-auto">
+          <table className="w-full" style={{ backgroundColor: theme.bgColor }}>
+            <thead>
+              <tr>
+                <th
+                  className="p-4 text-left"
+                  style={{ color: theme.secondaryTextColor }}
+                >
+                  Validator
+                </th>
+                <th
+                  className="p-4 text-left"
+                  style={{ color: theme.secondaryTextColor }}
+                >
+                  Rewards
+                </th>
+                <th
+                  className="p-4 text-left"
+                  style={{ color: theme.secondaryTextColor }}
+                >
+                  Action
+                </th>
+              </tr>
+            </thead>
+
+            <tbody>
+              {rewardsData?.rewards.map((rewardItem, index) => {
+                const akiiReward = rewardItem.reward.find(
+                  (r) => r.denom === "akii"
+                );
+                const formattedReward = akiiReward
+                  ? formatUnits(akiiReward.amount.split(".")[0]) + " KII"
+                  : "0 KII";
+
+                return (
+                  <tr key={index}>
+                    <td
+                      className="p-4 text-left break-all"
+                      style={{ color: theme.primaryTextColor }}
+                    >
+                      {validators[rewardItem.validator_address] ??
+                        rewardItem.validator_address}
+                    </td>
+                    <td
+                      className="p-4 text-left"
+                      style={{ color: theme.primaryTextColor }}
+                    >
+                      {formattedReward}
+                    </td>
+
+                    <td className="p-4 text-left">
+                      {!isConnected ? (
+                        <WagmiConnectButton />
+                      ) : isOwner ? (
+                        <button
+                          className={`px-4 py-2 rounded-md flex items-center gap-2 hover:opacity-80`}
+                          style={{
+                            backgroundColor: theme.boxColor,
+                            color: theme.accentColor,
+                          }}
+                          onClick={() =>
+                            handleClaim(rewardItem.validator_address)
+                          }
+                          disabled={withdrawRewardMutation.isPending}
+                        >
+                          {withdrawRewardMutation.isPending && (
+                            <FaSpinner className="animate-spin" />
+                          )}
+                          Claim
+                        </button>
+                      ) : (
+                        <span
+                          className="text-sm italic"
+                          style={{ color: theme.secondaryTextColor }}
+                        >
+                          Not available
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+
+              {rewardsData?.rewards?.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={3}
+                    className="p-4 text-center"
+                    style={{ color: theme.secondaryTextColor }}
+                  >
+                    No rewards available
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {isConnected &&
+        isOwner &&
+        rewardsData &&
+        rewardsData?.rewards?.length > 0 && (
+          <div className="flex justify-end mt-4">
+            <button
+              className={`px-4 py-2 rounded-md flex items-center gap-2 hover:opacity-80`}
+              style={{
+                backgroundColor: theme.bgColor,
+                color: theme.primaryTextColor,
+              }}
+              onClick={handleAllClaim}
+              disabled={withdrawRewardMutation.isPending}
+            >
+              {withdrawAllRewardMutation.isPending && (
+                <FaSpinner className="animate-spin" />
+              )}
+              Claim All
+            </button>
+          </div>
+        )}
+    </div>
+  );
+}

--- a/src/components/Account/StakesTable.tsx
+++ b/src/components/Account/StakesTable.tsx
@@ -17,7 +17,7 @@ import { formatAmount } from "../../utils/format";
 import { useHexToBech } from "@/services/hooks/addressConvertion";
 import { KIICHAIN_SYMBOL } from "@/config/chain";
 
-interface Theme {
+export interface Theme {
   boxColor: string;
   primaryTextColor: string;
   bgColor: string;

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -84,7 +84,7 @@ export default function Dashboard() {
       balanceData?.symbol ?? "KII"
     }`,
     staking: `${formatBalance(cosmosBalances?.stakingBalance ?? "0")} KII`,
-    reward: `${formatBalance(cosmosBalances?.rewardsBalance ?? "0")} KII`,
+    reward: `${cosmosBalances?.rewardsBalance ?? "0"} KII`,
     withdrawals: formatBalance("0") + " KII",
     stakes: [],
   };

--- a/src/services/contracts/distribution.ts
+++ b/src/services/contracts/distribution.ts
@@ -1,3 +1,4 @@
+import { CHAIN_LCD_ENDPOINT } from "@/config/chain";
 import { getDistributionPrecompileEthersV6Contract } from "@kiichain/kiijs-evm";
 import { ethers } from "ethers";
 import { WalletClient } from "viem";
@@ -37,7 +38,11 @@ export async function WithdrawAllRewards(walletClient: WalletClient) {
     const address = signer.address;
     const distPrecompile = getDistributionPrecompileEthersV6Contract(signer);
 
-    const tx = await distPrecompile.claimRewards(address, 50);
+    // SAFE_MAX_VAL is the safe amount of delegations to iterate, values higher than this will return gas error
+    // this means users only claim rewards for their first 50 delegations using this button
+    // other rewards must be claim manually
+    const SAFE_MAX_VAL = 50;
+    const tx = await distPrecompile.claimRewards(address, SAFE_MAX_VAL);
 
     return await tx.wait();
   } catch (error) {

--- a/src/services/contracts/distribution.ts
+++ b/src/services/contracts/distribution.ts
@@ -1,4 +1,3 @@
-import { CHAIN_LCD_ENDPOINT } from "@/config/chain";
 import { getDistributionPrecompileEthersV6Contract } from "@kiichain/kiijs-evm";
 import { ethers } from "ethers";
 import { WalletClient } from "viem";

--- a/src/services/contracts/distribution.ts
+++ b/src/services/contracts/distribution.ts
@@ -1,0 +1,47 @@
+import { getDistributionPrecompileEthersV6Contract } from "@kiichain/kiijs-evm";
+import { ethers } from "ethers";
+import { WalletClient } from "viem";
+
+// WithdrawDelegatorRewards withdraws the Staking rewards from an specific Validator
+export async function WithdrawDelegatorRewards(
+  validatorAddr: string,
+  walletClient: WalletClient
+) {
+  try {
+    if (!walletClient) throw new Error("Wallet not connected");
+
+    const provider = new ethers.BrowserProvider(walletClient.transport);
+    const signer = await provider.getSigner();
+    const address = signer.address;
+    const distPrecompile = getDistributionPrecompileEthersV6Contract(signer);
+
+    const tx = await distPrecompile.withdrawDelegatorRewards(
+      address,
+      validatorAddr
+    );
+
+    return await tx.wait();
+  } catch (error) {
+    console.error("Error trying to withdraw the staking reward:", error);
+    throw error;
+  }
+}
+
+// WithdrawAllRewards withdraws all Staking rewards
+export async function WithdrawAllRewards(walletClient: WalletClient) {
+  try {
+    if (!walletClient) throw new Error("Wallet not connected");
+
+    const provider = new ethers.BrowserProvider(walletClient.transport);
+    const signer = await provider.getSigner();
+    const address = signer.address;
+    const distPrecompile = getDistributionPrecompileEthersV6Contract(signer);
+
+    const tx = await distPrecompile.claimRewards(address, 50);
+
+    return await tx.wait();
+  } catch (error) {
+    console.error("Error trying to withdraw all staking reward:", error);
+    throw error;
+  }
+}

--- a/src/services/cosmos.ts
+++ b/src/services/cosmos.ts
@@ -1,6 +1,7 @@
 import { CHAIN_LCD_ENDPOINT } from "@/config/chain";
 import { formatAmount } from "@/utils/format";
 import { KIICHAIN_BASE_DENOM } from "@kiichain/kiijs-evm";
+import { formatUnits } from "ethers";
 
 interface DelegationResponse {
   balance?: {
@@ -11,10 +12,6 @@ interface DelegationResponse {
 interface Reward {
   denom: string;
   amount: string;
-}
-
-interface ValidatorReward {
-  reward?: Reward[];
 }
 
 export const cosmosService = {
@@ -41,16 +38,10 @@ export const cosmosService = {
       `${CHAIN_LCD_ENDPOINT}/cosmos/distribution/v1beta1/delegators/${kiiAddress}/rewards`
     );
     const data = await response.json();
-    return (
-      data.rewards?.reduce((acc: number, reward: ValidatorReward) => {
-        const kiiReward = reward.reward?.find(
-          (r: Reward) => r.denom === KIICHAIN_BASE_DENOM
-        );
-        const amount = kiiReward
-          ? parseFloat(formatAmount(kiiReward.amount))
-          : 0;
-        return acc + amount;
-      }, 0) || 0
+    const kiiReward = data.total.find(
+      (r: Reward) => r.denom == KIICHAIN_BASE_DENOM
     );
+
+    return formatUnits(kiiReward.amount.split(".")[0]) ?? 0;
   },
 };

--- a/src/services/mutations/distribution.ts
+++ b/src/services/mutations/distribution.ts
@@ -1,0 +1,63 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  WithdrawAllRewards,
+  WithdrawDelegatorRewards,
+} from "../contracts/distribution";
+
+// useWithdrawRewardsMutation executes the withdraw-reward function on the Distribution precompile
+export const useWithdrawRewardsMutation = () => {
+  const queryClient = useQueryClient();
+
+  type props = {
+    validatorAddr: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    walletClient: any;
+  };
+
+  return useMutation({
+    mutationFn: async ({ validatorAddr, walletClient }: props) =>
+      WithdrawDelegatorRewards(validatorAddr, walletClient),
+    onSuccess: () => {
+      toast.success("Successful withdrawal of your reward");
+      queryClient.invalidateQueries({
+        queryKey: ["rewards"],
+      });
+    },
+    onError: (error) => {
+      console.error("Undelegation error:", error);
+      toast.error("Failed to withdraw reward", {
+        description:
+          "Please try again or contact support if the problem persists",
+      });
+    },
+  });
+};
+
+// useWithdrawAllRewardsMutation executes the withdraw all rewards function on the Distribution precompile
+export const useWithdrawAllRewardsMutation = () => {
+  const queryClient = useQueryClient();
+
+  type props = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    walletClient: any;
+  };
+
+  return useMutation({
+    mutationFn: async ({ walletClient }: props) =>
+      WithdrawAllRewards(walletClient),
+    onSuccess: () => {
+      toast.success("Successful withdrawal all of your rewards");
+      queryClient.invalidateQueries({
+        queryKey: ["rewards"],
+      });
+    },
+    onError: (error) => {
+      console.error("Undelegation error:", error);
+      toast.error("Failed to withdraw all rewards", {
+        description:
+          "Please try again or contact support if the problem persists",
+      });
+    },
+  });
+};

--- a/src/services/queries/rewards.ts
+++ b/src/services/queries/rewards.ts
@@ -6,7 +6,11 @@ interface ValidatorReward {
   amount: string;
 }
 
-interface RewardsResponse {
+export interface RewardsResponse {
+  rewards: Array<{
+    validator_address: string;
+    reward: ValidatorReward[];
+  }>;
   total: Array<{
     denom: string;
     amount: string;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,5 +1,6 @@
 import * as kiiEvm from "@kiichain/kiijs-evm";
 import { ethers } from "ethers";
+import { WalletClient } from "viem";
 
 export const formatAmount = (amount: string): string => {
   const num = parseFloat(amount) / 1_000_000_000_000_000_000;
@@ -15,8 +16,7 @@ export async function SendIBCTokens(
   channel: string,
   amount: string,
   memo: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  walletClient: any,
+  walletClient: WalletClient,
   exponent: number,
   denom: string
 ) {


### PR DESCRIPTION
# Description

These changes add the following:
- Show user rewards on the main page
- Show user rewards on the profile page
- Show a table with the rewards per validator and its button, Claim
- Show a button to claim all rewards 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

This code has been tested locally

# Evidences
## Initial rewards
<img width="2027" height="1190" alt="image" src="https://github.com/user-attachments/assets/35fd1d78-babe-48af-b2b3-bdb96a5d2844" />

## Claiming
(We have spinning meaning loading)
<img width="2058" height="1402" alt="image" src="https://github.com/user-attachments/assets/f445f05e-d762-4d36-889b-cf5d465c8494" />


## Claimed
(The reward balance has changed)
<img width="2061" height="1420" alt="image" src="https://github.com/user-attachments/assets/9b1544eb-7785-447d-a572-6a8273b62ad9" />
